### PR TITLE
Fix normalize and modernize

### DIFF
--- a/src/api/modernize.ts
+++ b/src/api/modernize.ts
@@ -1,4 +1,4 @@
-import { get, set, each, fromPairs, toPairs } from 'lodash-es';
+import { get, set, unset, each, fromPairs, toPairs } from 'lodash-es';
 
 // TODO: This works. It'd be better if we added types. Maybe.
 //       Reevaluate if it becomes an issue
@@ -32,12 +32,19 @@ function modernizeAttachmentType(json: any, collection: any) {
     if (!val.type) return true;
     const parentId = getParentId(val, path[path.length - 2], json)
 
+    let oldId = null;
     if (val.id === val.subject || (parentId === 'items' && get(json, ['items', val.id]).id)) {
+      oldId = val.id;
       val.id = `${val.id}-${val.type}`;
     }
     set(json, ['items', val.id], val);
     if (parentId !== 'items') {
       set(json, ['attachments', 'items', parentId, val.id], val.type);
+      if (oldId) {
+        unset(json, ['attachments', 'items', parentId, oldId]);
+        unset(json, [collection, 'items', oldId]);
+        set(json, [collection, 'items', val.id], val);
+      }
     }
   });
 }

--- a/src/api/normalize.ts
+++ b/src/api/normalize.ts
@@ -1,10 +1,19 @@
-import { each, get } from 'lodash-es';
+import { each, get, flatMap, uniq } from 'lodash-es';
+
+function flattenAttachments(
+  attachments: { [items: string]: { [key: string]: { [key: string]: any } } | string[] }
+) {
+  attachments.items = uniq(flatMap(
+    attachments.items,
+    (attachments) => Object.keys(attachments as object)
+  ));
+}
 
 function itemsToArrays(json: any) {
   each(json, (val) => {
     if (!val) return;
     if (val.items) {
-      val.items = Object.values(val.items).map((id) => json.items[id as string]);
+      val.items = Object.values(val.items).map((id) => get(json, ['items', id as string], id));
     }
     if (val.item) {
       val.item = json.items[val.item];
@@ -12,12 +21,23 @@ function itemsToArrays(json: any) {
   });
 }
 
-function normalizeAttachments(attachments: { [key: string]: { [key: string]: string } }, parentId: string, items: { [key: string]: any }) {
+function normalizeAttachments(
+  attachments: { [key: string]: string },
+  parentId: string,
+  items: { [key: string]: any }) {
+
   const parent = items[parentId];
+
   each(attachments, (type, itemId) => {
+
+    // make sure the attachment references the parent
+    const attachment = items[itemId];
+    if (!attachment.subject) attachment.subject = parent;
+
+    // make sure the parent object has a collection of referenced attachments
     const coll = type + 's';
     if (!parent[coll]) parent[coll] = [];
-    parent[coll].push(items[itemId]);
+    parent[coll].push(attachment);
   });
 }
 
@@ -37,5 +57,6 @@ function normalizeItem(item: any, id: string | null, items: { [key: string]: any
 export function normalize(json: any) {
   each(json.items, normalizeItem);
   each(json.attachments.items, (attachments, parentId) => normalizeAttachments(attachments, parentId, json.items));
+  flattenAttachments(json.attachments);
   itemsToArrays(json);
 }

--- a/src/api/queries.ts
+++ b/src/api/queries.ts
@@ -207,7 +207,7 @@ function vehicle(settings: ApiSettings, propertyId: string, id: string, query: V
 }
 
 function violations(settings: ApiSettings, propertyId: string, query: ViolationsQuery, skipAuth: boolean = false): Promise<ViolationsPayload> {
-  return apiFetch(settings, 'GET', `/violations`, null, Object.assign({ scope: propertyId }, query), !skipAuth, 'authorizations', 'users');
+  return apiFetch(settings, 'GET', `/violations`, null, Object.assign({ scope: propertyId }, query), !skipAuth, 'notes');
 }
 
 function users(settings: ApiSettings, userId: string, query: UsersQuery, skipAuth: boolean = false): Promise<UsersPayload> {


### PR DESCRIPTION
- special cased notes and contacts have keys changed in items and attachments to `id-type` (old key / val pair removed)
- prevent null values being set into items arrays when setting references from items dict
- ensure all attachments reference parent through subject key
- flatten attachments objects to take advantage of transformation provided by itemsToArrays