### PR TITLE
add additional payload types

### DIFF
--- a/src/api/payloads/Payload.ts
+++ b/src/api/payloads/Payload.ts
@@ -6,6 +6,7 @@ export interface Entity {
   type: TypeString;
   generated?: string | Date;
   updated?: string | Date;
+  [key: string]: unknown;
 }
 
 export type Attachment = Record<IdString, TypeString>;

--- a/src/api/payloads/Payload.ts
+++ b/src/api/payloads/Payload.ts
@@ -11,8 +11,10 @@ export interface Entity {
 export type Attachment = Record<IdString, TypeString>;
 
 export type Items<T> = Record<IdString, T>;
+export type ItemPayload<T extends Payload> = Record<string, T[keyof T]>;
 
-export type EntityItems = Items<Entity>;
+// Include all implementations of the Payload interface
+export type EntityItems = Items<Entity> & ItemPayload<any>;
 export type AttachmentItems = Items<Attachment>;
 
 export interface Attachments {
@@ -26,4 +28,5 @@ export interface Payload  {
   version?: string;
   items: EntityItems;
   attachments?: Attachments;
+  scope?: string;
 }

--- a/src/api/payloads/PoliciesPayload.ts
+++ b/src/api/payloads/PoliciesPayload.ts
@@ -1,0 +1,7 @@
+import { Payload } from './Payload';
+
+export interface PoliciesPayload extends Payload {
+  policies: {
+    item: string
+  }
+}

--- a/src/api/payloads/PolicyPayload.ts
+++ b/src/api/payloads/PolicyPayload.ts
@@ -1,0 +1,6 @@
+import { Payload } from './Payload';
+
+export interface PolicyPayload extends Payload {
+  policy: string;
+  amenity: string;
+}

--- a/src/api/payloads/TenantPayload.ts
+++ b/src/api/payloads/TenantPayload.ts
@@ -1,4 +1,6 @@
 import { Payload } from './Payload';
 
 export interface TenantPayload extends Payload {
+    id?: string;
+    subject?: string;
 }

--- a/src/api/payloads/index.ts
+++ b/src/api/payloads/index.ts
@@ -5,6 +5,8 @@ export * from './AuthorizationsPayload';
 export * from './MediaPayload';
 export * from './MediasPayload';
 export * from './PermitsPayload';
+export * from './PoliciesPayload';
+export * from './PolicyPayload';
 export * from './TenantPayload';
 export * from './PropertyPayload';
 export * from './PropertiesPayload';


### PR DESCRIPTION
Adds to payload interfaces to properly type `boss-web` API
- Policy/Policies Payload: interfaces for the policy objects
- EntityItems change: included type for the lookup map for entities, e.g. spaces
